### PR TITLE
Add support for streaming PCAPs to mitmproxy

### DIFF
--- a/bin/httpreplay
+++ b/bin/httpreplay
@@ -6,6 +6,8 @@
 import argparse
 import logging
 
+import click
+
 import httpreplay.cobweb
 import httpreplay.misc
 import httpreplay.reader
@@ -16,34 +18,33 @@ from httpreplay.cut import (
     http_handler, https_handler, smtp_handler
 )
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("pcapfile", type=str, help="PCAP file")
-    parser.add_argument("tlsmaster", type=str, nargs="?", help="TLS master secrets file")
-    args = parser.parse_args()
+@click.command()
+@click.argument("pcapfile", type=click.File("rb"))
+@click.option("--tlsmaster", type=click.Path(file_okay=True), help="TLS master secrets file")
+def httpreplay(pcapfile, tlsmaster):
 
     logging.basicConfig(level=logging.INFO)
     log = logging.getLogger(__name__)
 
-    if args.tlsmaster:
-        tlsmaster = httpreplay.misc.read_tlsmaster(args.tlsmaster)
+    if tlsmaster:
+        tls_master_secrets = httpreplay.misc.read_tlsmaster(tlsmaster)
     else:
-        tlsmaster = {}
+        tls_master_secrets = {}
 
     handlers = {
         25: smtp_handler,
         80: http_handler,
         8000: http_handler,
         8080: http_handler,
-        443: lambda: https_handler(tlsmaster),
-        4443: lambda: https_handler(tlsmaster),
+        443: lambda: https_handler(tls_master_secrets),
+        4443: lambda: https_handler(tls_master_secrets),
     }
 
-    if args.pcapfile == "test":
-        httpreplay.test.test_suite()
-
-    reader = httpreplay.reader.PcapReader(args.pcapfile)
+    reader = httpreplay.reader.PcapReader(pcapfile)
     reader.tcp = httpreplay.smegma.TCPPacketStreamer(reader, handlers)
 
     for s, ts, protocol, sent, recv in reader.process():
         print s, "%f" % ts, protocol, getattr(sent, "uri", None)
+
+if __name__ == "__main__":
+    httpreplay()

--- a/bin/pcap2mitmproxy
+++ b/bin/pcap2mitmproxy
@@ -37,7 +37,8 @@ logging.basicConfig(level=logging.INFO)
 @click.argument("pcapfile", type=click.File("rb"))
 @click.argument("mitmfile", type=click.File("wb"))
 @click.option("--tlsmaster", type=click.Path(file_okay=True), help="TLS master secrets file")
-def convert(pcapfile, mitmfile, tlsmaster):
+@click.option('--stream/--no-stream', default=False)
+def convert(pcapfile, mitmfile, tlsmaster, stream):
     if tlsmaster:
         tlsmaster = read_tlsmaster(tlsmaster)
     else:
@@ -56,8 +57,12 @@ def convert(pcapfile, mitmfile, tlsmaster):
     reader.tcp = TCPPacketStreamer(reader, handlers)
     writer = FlowWriter(mitmfile)
 
-    # Sort the http/https requests and responses by their timestamp.
-    l = sorted(reader.process(), key=lambda x: x[1])
+
+    l = reader.process()
+    if not stream:
+        # Sort the http/https requests and responses by their timestamp.
+        l = sorted(l, key=lambda x: x[1])
+
     for addrs, timestamp, protocol, sent, recv in l:
         if protocol not in ("http", "https"):
             continue

--- a/bin/pcap2mitmproxy
+++ b/bin/pcap2mitmproxy
@@ -17,19 +17,15 @@ from httpreplay.cut import (
 from httpreplay.misc import read_tlsmaster
 
 try:
-    from libmproxy import models
-    from libmproxy.flow import FlowWriter
+    from mitmproxy import models
+    from mitmproxy.flow import FlowWriter
     from netlib.http import http1
+    from netlib.exceptions import HttpSyntaxException
 except ImportError:
-    try:
-        from mitmproxy import models
-        from mitmproxy.flow import FlowWriter
-        from netlib.http import http1
-    except ImportError:
-        sys.exit(
-            "In order to use this utility it is required to have the "
-            "mitmproxy tool installed (`pip install httpreplay[mitmproxy]`)"
-        )
+    sys.exit(
+        "In order to use this utility it is required to have the "
+        "mitmproxy tool installed (`pip install httpreplay[mitmproxy]`)"
+    )
 
 logging.basicConfig(level=logging.INFO)
 
@@ -86,8 +82,9 @@ def convert(pcapfile, mitmfile, tlsmaster, stream):
         if request_body_size > 0:
             request_body_size = -1
 
-        request.data.content = \
-            "".join(http1.read_body(req_io, request_body_size, None))
+        request.data.content, malformed = read_body(req_io, request_body_size)
+        if malformed:
+            request.headers["X-Mitmproxy-Malformed-Request-Body"] = "1"
 
         flow.request = models.HTTPRequest.wrap(request)
         flow.request.host, flow.request.port = dstip, dstport
@@ -100,12 +97,30 @@ def convert(pcapfile, mitmfile, tlsmaster, stream):
         if response_body_size > 0:
             response_body_size = -1
 
-        response.data.content = \
-            "".join(http1.read_body(resp_io, response_body_size, None))
+        response.data.content, malformed = read_body(resp_io, response_body_size)
+        if malformed:
+            response.headers["X-Mitmproxy-Malformed-Response-Body"] = "1"
 
         flow.response = models.HTTPResponse.wrap(response)
 
         writer.add(flow)
+
+def read_body(io, expected_size):
+    """
+    Read a (malformed) HTTP body.
+    Returns:
+        A (body: bytes, is_malformed: bool) tuple.
+    """
+    body_start = io.tell()
+    try:
+        content = b"".join(http1.read_body(io, expected_size, None))
+        if io.read():  # leftover?
+            raise HttpSyntaxException()
+        return content, False
+    except HttpSyntaxException:
+        io.seek(body_start)
+        return io.read(), True
+
 
 if __name__ == "__main__":
     convert()

--- a/bin/pcap2mitmproxy
+++ b/bin/pcap2mitmproxy
@@ -34,9 +34,9 @@ except ImportError:
 logging.basicConfig(level=logging.INFO)
 
 @click.command()
-@click.argument("pcapfile", type=click.Path(file_okay=True))
+@click.argument("pcapfile", type=click.File("rb"))
 @click.argument("mitmfile", type=click.File("wb"))
-@click.option("--tlsmaster", type=click.Path(file_okay=True))
+@click.option("--tlsmaster", type=click.Path(file_okay=True), help="TLS master secrets file")
 def convert(pcapfile, mitmfile, tlsmaster):
     if tlsmaster:
         tlsmaster = read_tlsmaster(tlsmaster)

--- a/httpreplay/reader.py
+++ b/httpreplay/reader.py
@@ -16,13 +16,13 @@ class PcapReader(object):
     having each packet processed by the various callback functions that can be
     provided by the user."""
 
-    def __init__(self, filepath):
+    def __init__(self, fp):
         self.tcp = None
         self.udp = None
         self.values = []
 
         try:
-            self.pcap = dpkt.pcap.Reader(open(filepath, "rb"))
+            self.pcap = dpkt.pcap.Reader(fp)
         except ValueError as e:
             if e.message == "invalid tcpdump header":
                 log.critical("Currently we don't support PCAP-NG files")

--- a/httpreplay/test.py
+++ b/httpreplay/test.py
@@ -259,24 +259,25 @@ def _pcap_2014_09_29(s, sent, recv):
 def test_suite():
     errors = 0
     for pcap in pcaps:
-        reader = httpreplay.reader.PcapReader(pcap["pcapfile"])
-        reader.tcp = \
-            httpreplay.smegma.TCPPacketStreamer(reader, pcap["handlers"])
+        with open(pcap["pcapfile"], "rb") as pcapfile:
+            reader = httpreplay.reader.PcapReader(pcapfile)
+            reader.tcp = \
+                httpreplay.smegma.TCPPacketStreamer(reader, pcap["handlers"])
 
-        count = 0
-        for s, ts, protocol, sent, recv in reader.process():
-            output = pcap["format"](s, ts, sent, recv)
-            if output not in pcap["output"]:
-                log.critical("Error in unittest output for %s: %s",
-                             pcap["pcapfile"], output)
-                errors += 1
-            count += 1
+            count = 0
+            for s, ts, protocol, sent, recv in reader.process():
+                output = pcap["format"](s, ts, sent, recv)
+                if output not in pcap["output"]:
+                    log.critical("Error in unittest output for %s: %s",
+                                 pcap["pcapfile"], output)
+                    errors += 1
+                count += 1
 
-        if pcap.get("output_count") and count != pcap["output_count"]:
-            log.critical(
-                "Incorrect output count determined for %s: %s instead of %s",
-                pcap["pcapfile"], count, pcap["output_count"]
-            )
+            if pcap.get("output_count") and count != pcap["output_count"]:
+                log.critical(
+                    "Incorrect output count determined for %s: %s instead of %s",
+                    pcap["pcapfile"], count, pcap["output_count"]
+                )
 
     log.info("Found %d errors.", errors)
     exit(1 if errors else 0)


### PR DESCRIPTION
In a nutshell, this allows live PCAP processing with mitmproxy, at least for HTTP. :smiley: :tada: 
```
tail -f -c +0 data/dump.pcap | pcap2mitmproxy --stream - - | mitmdump -s details.py -n -r - 
```

I replaced argparse with click, because click treats `-` as stdin/stdout automatically. There are also a few fixes to make pcap2mitmproxy more resilient against invalid input.