### PR TITLE
Don't overwrite banner if a second 220 status is found

### DIFF
--- a/httpreplay/cobweb.py
+++ b/httpreplay/cobweb.py
@@ -389,7 +389,7 @@ class SmtpProtocol(Protocol):
 
             if self.rescode == 250:
                 self.reply.ok_responses.extend(filter(None, reply.split("\r\n")))
-            elif self.rescode == 220:
+            elif self.rescode == 220 and self.reply.ready_message is None:
                 self.reply.ready_message = reply
 
 class SmtpRequest(object):

--- a/tests/test_smtp.py
+++ b/tests/test_smtp.py
@@ -129,3 +129,19 @@ def test_read_smtp_ready_message():
     test = SmtpTest(os.path.join("tests", "pcaps", "smtp-auth-login.pcap"))
     sent, recv = test.get_sent_recv()
     assert recv.ready_message == "220 smtp006.mail.xxx.xxxxx.com ESMTP\r\n"
+
+    # In case of starttls, status 220 is used twice. Test if the banner
+    # is still extracted
+    smtp = SmtpProtocol()
+    smtp.init()
+    smtp.parse_reply("220 example.com (Tosti01) ESMTP Service ready\r\n")
+    smtp.parse_reply(
+        "250-example.com Hello WORKSTATION-42 [192.168.1.100]\r\n"
+        "250-AUTH LOGIN PLAIN\r\n"
+        "250-SIZE 69920427\r\n"
+        "250 STARTTLS\r\n"
+    )
+    smtp.parse_reply("220 OK STARTTLS ready\r\n")
+    assert smtp.reply.ready_message == (
+        "220 example.com (Tosti01) ESMTP Service ready\r\n"
+    )


### PR DESCRIPTION
If a second 220 status was found from the SMTP server, the message from this code would overwrite the stored ready_message/banner. It will not do this anymore after this change.